### PR TITLE
Add order entity

### DIFF
--- a/app/(dashboard)/[storeId]/(routes)/orders/components/cell-action.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/orders/components/cell-action.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Copy } from "lucide-react";
+import toast from "react-hot-toast";
+
+import { OrderColumn } from "./columns";
+
+interface CellActionProps {
+  data: OrderColumn;
+}
+
+export const CellAction: React.FC<CellActionProps> = ({ data }) => {
+  const onCopy = (id: string) => {
+    navigator.clipboard.writeText(id);
+    toast.success("Order ID copied to the clipboard.");
+  };
+
+  return (
+    <Button variant="ghost" className="h-8 w-8 p-0" onClick={() => onCopy(data.id)}>
+      <span className="sr-only">Copy id</span>
+      <Copy className="h-4 w-4" />
+    </Button>
+  );
+};

--- a/app/(dashboard)/[storeId]/(routes)/orders/components/client.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/orders/components/client.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Heading } from "@/components/ui/heading";
+import { Separator } from "@/components/ui/separator";
+import { DataTable } from "@/components/ui/data-table";
+import { OrderColumn, columns } from "./columns";
+
+interface OrderClientProps {
+  data: OrderColumn[];
+}
+
+export const OrderClient: React.FC<OrderClientProps> = ({ data }) => {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Heading
+          title={`Orders (${data.length})`}
+          description="Manage orders for your store"
+        />
+      </div>
+      <Separator />
+      <DataTable searchKey="products" columns={columns} data={data} />
+    </>
+  );
+};

--- a/app/(dashboard)/[storeId]/(routes)/orders/components/columns.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/orders/components/columns.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { CellAction } from "./cell-action";
+
+export type OrderColumn = {
+  id: string;
+  phone: string;
+  address: string;
+  products: string;
+  isPaid: boolean;
+  createdAt: string;
+};
+
+export const columns: ColumnDef<OrderColumn>[] = [
+  {
+    accessorKey: "phone",
+    header: "Phone",
+  },
+  {
+    accessorKey: "address",
+    header: "Address",
+  },
+  {
+    accessorKey: "products",
+    header: "Products",
+  },
+  {
+    accessorKey: "isPaid",
+    header: "Paid",
+  },
+  {
+    accessorKey: "createdAt",
+    header: "Date",
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <CellAction data={row.original} />,
+  },
+];

--- a/app/(dashboard)/[storeId]/(routes)/orders/page.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/orders/page.tsx
@@ -1,0 +1,42 @@
+import { format } from "date-fns";
+
+import prismadb from "@/lib/prismadb";
+import { OrderClient } from "./components/client";
+import { OrderColumn } from "./components/columns";
+
+const OrdersPage = async ({ params }: { params: { storeId: string } }) => {
+  const orders = await prismadb.order.findMany({
+    where: {
+      storeId: params.storeId,
+    },
+    include: {
+      orderItems: {
+        include: {
+          product: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  const formattedOrders: OrderColumn[] = orders.map((item) => ({
+    id: item.id,
+    phone: item.phone,
+    address: item.address,
+    products: item.orderItems.map((oi) => oi.product.name).join(", "),
+    isPaid: item.isPaid,
+    createdAt: format(item.createdAt, "MMMM do, yyyy"),
+  }));
+
+  return (
+    <div className="flex-col">
+      <div className="flex-1 space-y-4 p-8 pt-6">
+        <OrderClient data={formattedOrders} />
+      </div>
+    </div>
+  );
+};
+
+export default OrdersPage;

--- a/app/api/[storeId]/orders/[orderId]/route.ts
+++ b/app/api/[storeId]/orders/[orderId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import prismadb from "@/lib/prismadb";
+
+export async function GET(req: Request, { params }: { params: { orderId: string } }) {
+  try {
+    const order = await prismadb.order.findUnique({
+      where: { id: params.orderId },
+      include: {
+        orderItems: { include: { product: true } },
+      },
+    });
+
+    return NextResponse.json(order);
+  } catch (error) {
+    console.log('[ORDER_GET]', error);
+    return new NextResponse("Internal Error", { status: 500 });
+  }
+}
+
+export async function PATCH(req: Request, { params }: { params: { orderId: string } }) {
+  try {
+    const body = await req.json();
+    const { phone, address, isPaid } = body;
+
+    const order = await prismadb.order.update({
+      where: { id: params.orderId },
+      data: {
+        phone,
+        address,
+        isPaid,
+      },
+      include: {
+        orderItems: { include: { product: true } },
+      },
+    });
+
+    return NextResponse.json(order);
+  } catch (error) {
+    console.log('[ORDER_PATCH]', error);
+    return new NextResponse("Internal Error", { status: 500 });
+  }
+}
+
+export async function DELETE(req: Request, { params }: { params: { orderId: string } }) {
+  try {
+    const order = await prismadb.order.delete({
+      where: { id: params.orderId },
+    });
+
+    return NextResponse.json(order);
+  } catch (error) {
+    console.log('[ORDER_DELETE]', error);
+    return new NextResponse("Internal Error", { status: 500 });
+  }
+}

--- a/app/api/[storeId]/orders/route.ts
+++ b/app/api/[storeId]/orders/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import prismadb from "@/lib/prismadb";
+
+export async function POST(req: Request, { params }: { params: { storeId: string } }) {
+  try {
+    const body = await req.json();
+    const { productIds, phone, address, isPaid } = body;
+
+    if (!productIds || !productIds.length) {
+      return new NextResponse("Product ids are required", { status: 400 });
+    }
+
+    if (!phone) {
+      return new NextResponse("Phone is required", { status: 400 });
+    }
+
+    if (!address) {
+      return new NextResponse("Address is required", { status: 400 });
+    }
+
+    const order = await prismadb.order.create({
+      data: {
+        storeId: params.storeId,
+        phone,
+        address,
+        isPaid: isPaid || false,
+        orderItems: {
+          create: productIds.map((productId: string) => ({ productId })),
+        },
+      },
+      include: {
+        orderItems: true,
+      },
+    });
+
+    return NextResponse.json(order, { status: 201 });
+  } catch (error) {
+    console.log('[ORDERS_POST]', error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}
+
+export async function GET(req: Request, { params }: { params: { storeId: string } }) {
+  try {
+    const orders = await prismadb.order.findMany({
+      where: { storeId: params.storeId },
+      include: {
+        orderItems: { include: { product: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(orders);
+  } catch (error) {
+    console.log('[ORDERS_GET]', error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -44,6 +44,11 @@ export function MainNav({
       active: pathname === `/${params.storeId}/products`,
     },
     {
+      href: `/${params.storeId}/orders`,
+      label: "Orders",
+      active: pathname === `/${params.storeId}/orders`,
+    },
+    {
       href: `/${params.storeId}/settings`,
       label: "Settings",
       active: pathname === `/${params.storeId}/settings`,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Store {
   sizes      Size[]      @relation("StoreToSize")
   colors     Color[]     @relation("StoreToColor")
   products   Product[]   @relation("StoreToProduct")
+  orders     Order[]     @relation("StoreToOrder")
   createdAt  DateTime    @default(now())
   updatedAt  DateTime    @updatedAt
 }
@@ -96,6 +97,7 @@ model Product {
   colorId    String
   color      Color    @relation(fields: [colorId], references: [id])
   images     Image[]
+  orderItems OrderItem[]
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
@@ -113,5 +115,30 @@ model Image {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([productId])
+}
+
+model Order {
+  id         String      @id @default(uuid())
+  storeId    String
+  store      Store       @relation("StoreToOrder", fields: [storeId], references: [id])
+  orderItems OrderItem[]
+  isPaid     Boolean     @default(false)
+  phone      String      @default("")
+  address    String      @default("")
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @updatedAt
+
+  @@index([storeId])
+}
+
+model OrderItem {
+  id        String   @id @default(uuid())
+  orderId   String
+  order     Order    @relation(fields: [orderId], references: [id])
+  productId String
+  product   Product  @relation(fields: [productId], references: [id])
+
+  @@index([orderId])
   @@index([productId])
 }


### PR DESCRIPTION
## Summary
- add `Order` and `OrderItem` models with relations
- expose CRUD API routes for orders
- add dashboard page to list orders
- extend main navigation with Orders link

## Testing
- `npm run lint` *(fails: next not found)*